### PR TITLE
Introduce DSL module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ output.
 - Markdown ([CommonMark](https://commonmark.org/) spec)
   - Except embedded HTML
   - Except images
+- Kotlin DSL
 
 #### Target outputs
 
@@ -28,7 +29,6 @@ output.
 
 - Proper documentation, both in code and published online
 - Release artifact(s)
-- DSL for writing rich text in Kotlin
 - Support some HTML tags as input
 - Support some HTML tags embedded in Markdown
 - Support Markdown tables

--- a/crt-dsl/build.gradle.kts
+++ b/crt-dsl/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    `project-library`
+}
+
+dependencies {
+    api(project(":crt-api"))
+
+    testImplementation(libs.test.junit.jupiter)
+    testImplementation(libs.test.assertk)
+    testImplementation(libs.test.mockito)
+}

--- a/crt-dsl/src/main/kotlin/nl/jjkester/crt/dsl/Dsl.kt
+++ b/crt-dsl/src/main/kotlin/nl/jjkester/crt/dsl/Dsl.kt
@@ -1,0 +1,64 @@
+package nl.jjkester.crt.dsl
+
+import nl.jjkester.crt.api.model.Container
+import nl.jjkester.crt.api.model.Node
+import nl.jjkester.crt.dsl.internal.resolve
+
+@DslMarker
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+internal annotation class RichTextDsl
+
+@RichTextDsl
+public interface BlockScope {
+
+    public fun blockquote(init: BlockScope.() -> Unit)
+
+    public fun code(content: String, languageHint: String? = null)
+
+    public fun code(languageHint: String? = null, init: LeafScope.() -> Unit)
+
+    public fun divider()
+
+    public fun heading(level: Int, init: SpanScope.() -> Unit)
+
+    public fun orderedList(init: ListScope.() -> Unit)
+
+    public fun paragraph(init: SpanScope.() -> Unit)
+
+    public fun unorderedList(init: ListScope.() -> Unit)
+}
+
+@RichTextDsl
+public interface ListScope {
+
+    public fun listItem(init: BlockScope.() -> Unit)
+}
+
+@RichTextDsl
+public interface SpanScope {
+
+    public fun code(content: String, languageHint: String? = null)
+
+    public fun code(languageHint: String? = null, init: LeafScope.() -> Unit)
+
+    public fun emphasis(init: SpanScope.() -> Unit)
+
+    public fun link(destination: String, init: SpanScope.() -> Unit)
+
+    public fun strongEmphasis(init: SpanScope.() -> Unit)
+
+    public fun text(text: String)
+
+    public operator fun String.unaryPlus(): Unit = text(this)
+}
+
+@RichTextDsl
+public interface LeafScope {
+
+    public operator fun String.unaryPlus()
+}
+
+public fun buildRichText(init: BlockScope.() -> Unit): Node {
+    return Container(init.resolve(), null)
+}

--- a/crt-dsl/src/main/kotlin/nl/jjkester/crt/dsl/internal/AbstractNodeContentBuilder.kt
+++ b/crt-dsl/src/main/kotlin/nl/jjkester/crt/dsl/internal/AbstractNodeContentBuilder.kt
@@ -1,0 +1,15 @@
+package nl.jjkester.crt.dsl.internal
+
+import nl.jjkester.crt.api.model.Node
+
+internal abstract class AbstractNodeContentBuilder<T : Node> {
+
+    private val _children: MutableList<T> = mutableListOf()
+
+    val children: List<T>
+        get() = _children.toList()
+
+    protected fun add(node: T) {
+        _children.add(node)
+    }
+}

--- a/crt-dsl/src/main/kotlin/nl/jjkester/crt/dsl/internal/BlockNodeContentBuilder.kt
+++ b/crt-dsl/src/main/kotlin/nl/jjkester/crt/dsl/internal/BlockNodeContentBuilder.kt
@@ -1,0 +1,53 @@
+package nl.jjkester.crt.dsl.internal
+
+import nl.jjkester.crt.api.model.Blockquote
+import nl.jjkester.crt.api.model.CodeBlock
+import nl.jjkester.crt.api.model.Divider
+import nl.jjkester.crt.api.model.Heading
+import nl.jjkester.crt.api.model.Language
+import nl.jjkester.crt.api.model.Node
+import nl.jjkester.crt.api.model.OrderedList
+import nl.jjkester.crt.api.model.Paragraph
+import nl.jjkester.crt.api.model.UnorderedList
+import nl.jjkester.crt.dsl.BlockScope
+import nl.jjkester.crt.dsl.LeafScope
+import nl.jjkester.crt.dsl.ListScope
+import nl.jjkester.crt.dsl.SpanScope
+
+internal class BlockNodeContentBuilder : AbstractNodeContentBuilder<Node.Block>(), BlockScope {
+
+    override fun blockquote(init: BlockScope.() -> Unit) {
+        add(Blockquote(init.resolve(), null))
+    }
+
+    override fun code(content: String, languageHint: String?) {
+        add(CodeBlock(content, languageHint?.let(::Language), null))
+    }
+
+    override fun code(languageHint: String?, init: LeafScope.() -> Unit) {
+        code(init.resolve(), languageHint)
+    }
+
+    override fun divider() {
+        add(Divider(null))
+    }
+
+    override fun heading(level: Int, init: SpanScope.() -> Unit) {
+        val parsedLevel = requireNotNull(Heading.Level.fromIntOrNull(level)) { "Invalid heading level" }
+        add(Heading(parsedLevel, init.resolve(), null))
+    }
+
+    override fun orderedList(init: ListScope.() -> Unit) {
+        add(OrderedList(init.resolve(), null))
+    }
+
+    override fun paragraph(init: SpanScope.() -> Unit) {
+        add(Paragraph(init.resolve(), null))
+    }
+
+    override fun unorderedList(init: ListScope.() -> Unit) {
+        add(UnorderedList(init.resolve(), null))
+    }
+}
+
+internal fun (BlockScope.() -> Unit).resolve(): List<Node.Block> = BlockNodeContentBuilder().apply(this).children

--- a/crt-dsl/src/main/kotlin/nl/jjkester/crt/dsl/internal/LeafNodeContentBuilder.kt
+++ b/crt-dsl/src/main/kotlin/nl/jjkester/crt/dsl/internal/LeafNodeContentBuilder.kt
@@ -1,0 +1,17 @@
+package nl.jjkester.crt.dsl.internal
+
+import nl.jjkester.crt.dsl.LeafScope
+
+internal class LeafNodeContentBuilder : LeafScope {
+
+    private val builder = StringBuilder()
+
+    val string: String
+        get() = builder.toString()
+
+    override fun String.unaryPlus() {
+        builder.append(this)
+    }
+}
+
+internal fun (LeafScope.() -> Unit).resolve(): String = LeafNodeContentBuilder().apply(this).string

--- a/crt-dsl/src/main/kotlin/nl/jjkester/crt/dsl/internal/ListNodeContentBuilder.kt
+++ b/crt-dsl/src/main/kotlin/nl/jjkester/crt/dsl/internal/ListNodeContentBuilder.kt
@@ -1,0 +1,14 @@
+package nl.jjkester.crt.dsl.internal
+
+import nl.jjkester.crt.api.model.ListItem
+import nl.jjkester.crt.dsl.BlockScope
+import nl.jjkester.crt.dsl.ListScope
+
+internal class ListNodeContentBuilder : AbstractNodeContentBuilder<ListItem>(), ListScope {
+
+    override fun listItem(init: BlockScope.() -> Unit) {
+        add(ListItem(init.resolve(), null))
+    }
+}
+
+internal fun (ListScope.() -> Unit).resolve(): List<ListItem> = ListNodeContentBuilder().apply(this).children

--- a/crt-dsl/src/main/kotlin/nl/jjkester/crt/dsl/internal/SpanNodeContentBuilder.kt
+++ b/crt-dsl/src/main/kotlin/nl/jjkester/crt/dsl/internal/SpanNodeContentBuilder.kt
@@ -1,0 +1,40 @@
+package nl.jjkester.crt.dsl.internal
+
+import nl.jjkester.crt.api.model.Code
+import nl.jjkester.crt.api.model.Emphasis
+import nl.jjkester.crt.api.model.Language
+import nl.jjkester.crt.api.model.Link
+import nl.jjkester.crt.api.model.Node
+import nl.jjkester.crt.api.model.StrongEmphasis
+import nl.jjkester.crt.api.model.Text
+import nl.jjkester.crt.dsl.LeafScope
+import nl.jjkester.crt.dsl.SpanScope
+
+internal class SpanNodeContentBuilder : AbstractNodeContentBuilder<Node.Span>(), SpanScope {
+
+    override fun code(content: String, languageHint: String?) {
+        add(Code(content, languageHint?.let(::Language), null))
+    }
+
+    override fun code(languageHint: String?, init: LeafScope.() -> Unit) {
+        code(init.resolve(), languageHint)
+    }
+
+    override fun emphasis(init: SpanScope.() -> Unit) {
+        add(Emphasis(init.resolve(), null))
+    }
+
+    override fun link(destination: String, init: SpanScope.() -> Unit) {
+        add(Link(Link.Destination(destination), init.resolve(), null))
+    }
+
+    override fun strongEmphasis(init: SpanScope.() -> Unit) {
+        add(StrongEmphasis(init.resolve(), null))
+    }
+
+    override fun text(text: String) {
+        add(Text(text, null))
+    }
+}
+
+internal fun (SpanScope.() -> Unit).resolve(): List<Node.Span> = SpanNodeContentBuilder().apply(this).children

--- a/crt-dsl/src/test/kotlin/nl/jjkester/crt/dsl/DslKtTest.kt
+++ b/crt-dsl/src/test/kotlin/nl/jjkester/crt/dsl/DslKtTest.kt
@@ -1,0 +1,257 @@
+package nl.jjkester.crt.dsl
+
+import assertk.Assert
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.each
+import assertk.assertions.hasSize
+import assertk.assertions.index
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEmpty
+import assertk.assertions.single
+import nl.jjkester.crt.api.model.Blockquote
+import nl.jjkester.crt.api.model.Code
+import nl.jjkester.crt.api.model.CodeBlock
+import nl.jjkester.crt.api.model.Container
+import nl.jjkester.crt.api.model.Divider
+import nl.jjkester.crt.api.model.Emphasis
+import nl.jjkester.crt.api.model.Heading
+import nl.jjkester.crt.api.model.Language
+import nl.jjkester.crt.api.model.Link
+import nl.jjkester.crt.api.model.ListItem
+import nl.jjkester.crt.api.model.Node
+import nl.jjkester.crt.api.model.OrderedList
+import nl.jjkester.crt.api.model.Paragraph
+import nl.jjkester.crt.api.model.StrongEmphasis
+import nl.jjkester.crt.api.model.Text
+import nl.jjkester.crt.api.model.UnorderedList
+import org.junit.jupiter.api.Test
+
+class DslKtTest {
+
+    @Test
+    fun buildRichText() {
+        val result = buildRichText {
+            heading(1) {
+                +"Hello, "
+                code("compose-rich-text", "text")
+                +"!"
+            }
+            paragraph {
+                +"Documentation can be found on "
+                link("https://github.com/jjkester/compose-rich-text") {
+                    +"GitHub"
+                }
+                +"."
+            }
+            divider()
+            blockquote {
+                paragraph {
+                    +"Hello world"
+                    emphasis {
+                        +"Every software developer"
+                    }
+                }
+                code("kotlin") {
+                    +"data class KotlinCompose(val isAwesome: Boolean = true)"
+                }
+            }
+            orderedList {
+                listItem {
+                    paragraph {
+                        +"One"
+                    }
+                }
+                listItem {
+                    paragraph {
+                        +"Two"
+                    }
+                }
+            }
+            unorderedList {
+                listItem {
+                    paragraph {
+                        strongEmphasis {
+                            +"Foo"
+                        }
+                    }
+                }
+                listItem {
+                    paragraph {
+                        +"Bar"
+                    }
+                }
+            }
+        }
+
+        assertThat(result).isContainerNode(children = 6) {
+            index(0).isHeadingNode(level = Heading.Level.One, children = 3) {
+                index(0).isTextNode("Hello, ")
+                index(1).isCodeNode("compose-rich-text", languageHint = Language("text"))
+                index(2).isTextNode("!")
+            }
+            index(1).isParagraphNode(children = 3) {
+                index(0).isTextNode()
+                index(1).isLinkNode(
+                    destination = Link.Destination("https://github.com/jjkester/compose-rich-text"),
+                    children = 1
+                ) {
+                    single().isTextNode("GitHub")
+                }
+                index(2).isTextNode()
+            }
+            index(2).isDividerNode()
+            index(3).isBlockquoteNode(children = 2) {
+                index(0).isParagraphNode(children = 2) {
+                    index(0).isTextNode()
+                    index(1).isEmphasisNode(children = 1) {
+                        single().isTextNode()
+                    }
+                }
+                index(1).isCodeBlockNode(languageHint = Language("kotlin")) {
+                    isNotEmpty()
+                }
+            }
+            index(4).isOrderedListNode(children = 2) {
+                each {
+                    it.isListItemNode(child = true) {
+                        isParagraphNode(children = 1) {
+                            single().isTextNode()
+                        }
+                    }
+                }
+            }
+            index(5).isUnorderedListNode(children = 2) {
+                index(0).isListItemNode(child = true) {
+                    isParagraphNode(children = 1) {
+                        single().isStrongEmphasisNode(children = 1) {
+                            single().isTextNode()
+                        }
+                    }
+                }
+                index(1).isListItemNode(child = true) {
+                    isParagraphNode(children = 1) {
+                        single().isTextNode()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun <T : Node> Assert<T>.isContainerNode(
+        children: Int = 0,
+        body: Assert<List<Node>>.() -> Unit = {}
+    ) {
+        isInstanceOf<Container>().hasChildNodes(children, body)
+    }
+
+    private fun <T : Node> Assert<T>.isBlockquoteNode(
+        children: Int = 0,
+        body: Assert<List<Node>>.() -> Unit = {}
+    ) {
+        isInstanceOf<Blockquote>().hasChildNodes(children, body)
+    }
+
+    private fun <T : Node> Assert<T>.isCodeBlockNode(
+        languageHint: Language,
+        body: Assert<String>.() -> Unit
+    ) {
+        isInstanceOf<CodeBlock>().all {
+            transform { it.languageHint }.isEqualTo(languageHint)
+            transform { it.content }.body()
+        }
+    }
+
+    private fun <T : Node> Assert<T>.isDividerNode() {
+        isInstanceOf<Divider>()
+    }
+
+    private fun <T : Node> Assert<T>.isHeadingNode(
+        level: Heading.Level,
+        children: Int = 0,
+        body: Assert<List<Node>>.() -> Unit = {}
+    ) {
+        isInstanceOf<Heading>().all {
+            transform { it.level }.isEqualTo(level)
+            hasChildNodes(children, body)
+        }
+    }
+
+    private fun <T : Node> Assert<T>.isOrderedListNode(
+        children: Int = 0,
+        body: Assert<List<Node>>.() -> Unit = {}
+    ) {
+        isInstanceOf<OrderedList>().hasChildNodes(children, body)
+    }
+
+    private fun <T : Node> Assert<T>.isParagraphNode(
+        children: Int = 0,
+        body: Assert<List<Node>>.() -> Unit = {}
+    ) {
+        isInstanceOf<Paragraph>().hasChildNodes(children, body)
+    }
+
+    private fun <T : Node> Assert<T>.isUnorderedListNode(
+        children: Int = 0,
+        body: Assert<List<Node>>.() -> Unit = {}
+    ) {
+        isInstanceOf<UnorderedList>().hasChildNodes(children, body)
+    }
+
+    private fun <T : Node> Assert<T>.isListItemNode(
+        child: Boolean = false,
+        body: Assert<Node>.() -> Unit = {}
+    ) {
+        isInstanceOf<ListItem>().hasChildNodes(if (child) 1 else 0) {
+            single().body()
+        }
+    }
+
+    private fun Assert<Node>.isCodeNode(content: String, languageHint: Language) {
+        isInstanceOf<Code>().all {
+            transform { it.languageHint }.isEqualTo(languageHint)
+            transform { it.content }.isEqualTo(content)
+        }
+    }
+
+    private fun <T : Node> Assert<T>.isEmphasisNode(
+        children: Int = 0,
+        body: Assert<List<Node>>.() -> Unit = {}
+    ) {
+        isInstanceOf<Emphasis>().hasChildNodes(children, body)
+    }
+
+    private fun Assert<Node>.isLinkNode(
+        destination: Link.Destination,
+        children: Int = 0,
+        body: Assert<List<Node>>.() -> Unit = {}
+    ) {
+        isInstanceOf<Link>().all {
+            transform { it.destination }.isEqualTo(destination)
+            hasChildNodes(children, body)
+        }
+    }
+
+    private fun <T : Node> Assert<T>.isStrongEmphasisNode(
+        children: Int = 0,
+        body: Assert<List<Node>>.() -> Unit = {}
+    ) {
+        isInstanceOf<StrongEmphasis>().hasChildNodes(children, body)
+    }
+
+    private fun <T : Node> Assert<T>.isTextNode() {
+        isInstanceOf<Text>()
+    }
+
+    private fun <T : Node> Assert<T>.isTextNode(text: String) {
+        isInstanceOf<Text>().transform { it.text }.isEqualTo(text)
+    }
+
+    private fun Assert<Node>.hasChildNodes(size: Int, body: Assert<List<Node>>.() -> Unit) {
+        transform { it.children }.all {
+            hasSize(size)
+            body()
+        }
+    }
+}

--- a/crt-dsl/src/test/kotlin/nl/jjkester/crt/dsl/internal/LeafNodeContentBuilderTest.kt
+++ b/crt-dsl/src/test/kotlin/nl/jjkester/crt/dsl/internal/LeafNodeContentBuilderTest.kt
@@ -1,0 +1,33 @@
+package nl.jjkester.crt.dsl.internal
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+
+class LeafNodeContentBuilderTest {
+
+    @Test
+    fun `no calls`() {
+        val systemUnderTest = LeafNodeContentBuilder()
+
+        assertThat(systemUnderTest.string).isEmpty()
+    }
+
+    @Test
+    fun `single call`() {
+        val systemUnderTest = LeafNodeContentBuilder().apply { +"Hello, world" }
+
+        assertThat(systemUnderTest.string).isEqualTo("Hello, world")
+    }
+
+    @Test
+    fun `multiple calls`() {
+        val systemUnderTest = LeafNodeContentBuilder().apply {
+            +"Hello, "
+            +"world"
+        }
+
+        assertThat(systemUnderTest.string).isEqualTo("Hello, world")
+    }
+}

--- a/crt-dsl/src/test/kotlin/nl/jjkester/crt/dsl/internal/ListNodeContentBuilderTest.kt
+++ b/crt-dsl/src/test/kotlin/nl/jjkester/crt/dsl/internal/ListNodeContentBuilderTest.kt
@@ -1,0 +1,54 @@
+package nl.jjkester.crt.dsl.internal
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.index
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.single
+import nl.jjkester.crt.api.model.ListItem
+import nl.jjkester.crt.api.model.Paragraph
+import nl.jjkester.crt.api.model.Text
+import org.junit.jupiter.api.Test
+
+class ListNodeContentBuilderTest {
+
+    @Test
+    fun `no items`() {
+        val systemUnderTest = ListNodeContentBuilder()
+
+        assertThat(systemUnderTest.children).isEmpty()
+    }
+
+    @Test
+    fun `one item`() {
+        val systemUnderTest = ListNodeContentBuilder().apply { listItem { paragraph { +"Hello, world" } } }
+
+        assertThat(systemUnderTest.children).single()
+            .transform { it.childParagraphText }.isEqualTo("Hello, world")
+    }
+
+    @Test
+    fun `two items`() {
+        val systemUnderTest = ListNodeContentBuilder().apply {
+            listItem { paragraph { +"Foo" } }
+            listItem { paragraph { +"Bar" } }
+        }
+
+        assertThat(systemUnderTest.children).all {
+            hasSize(2)
+            index(0).transform { it.childParagraphText }.isEqualTo("Foo")
+            index(1).transform { it.childParagraphText }.isEqualTo("Bar")
+        }
+    }
+
+    private val ListItem.childParagraphText: String
+        get() = children.filterIsInstance<Paragraph>()
+            .firstOrNull()
+            ?.children
+            ?.filterIsInstance<Text>()
+            ?.firstOrNull()
+            ?.text
+            .orEmpty()
+}

--- a/crt-dsl/src/test/kotlin/nl/jjkester/crt/dsl/internal/SpanNodeContentBuilderTest.kt
+++ b/crt-dsl/src/test/kotlin/nl/jjkester/crt/dsl/internal/SpanNodeContentBuilderTest.kt
@@ -1,0 +1,43 @@
+package nl.jjkester.crt.dsl.internal
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.single
+import nl.jjkester.crt.api.model.Code
+import nl.jjkester.crt.api.model.Language
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SpanNodeContentBuilderTest {
+
+    @Nested
+    inner class `Code function` {
+
+        @Test
+        fun string() {
+            val systemUnderTest = SpanNodeContentBuilder().apply { code("<html></html>", "html") }
+
+            assertThat(systemUnderTest.children).single().isInstanceOf<Code>().all {
+                transform { it.content }.isEqualTo("<html></html>")
+                transform { it.languageHint }.isEqualTo(Language("html"))
+            }
+        }
+
+        @Test
+        fun builder() {
+            val systemUnderTest = SpanNodeContentBuilder().apply {
+                code("html") {
+                    +"<html>"
+                    +"</html>"
+                }
+            }
+
+            assertThat(systemUnderTest.children).single().isInstanceOf<Code>().all {
+                transform { it.content }.isEqualTo("<html></html>")
+                transform { it.languageHint }.isEqualTo(Language("html"))
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ dependencyResolutionManagement {
 include(":crt-api")
 include(":crt-common")
 include(":crt-demo")
+include(":crt-dsl")
 include(":crt-parser-markdown")
 include(":crt-renderer-compose")
 include(":utils:slf4j-android")


### PR DESCRIPTION
DSLs can be used as an alternative to the parsers, and are useful when testing the renderer module.